### PR TITLE
deps: pin pepc to its GitHub release URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "Pyarrow",
     "numpy",
     "pandas>=2.1.0",
-    "pepc>=2.0.1",
+    "pepc @ git+https://github.com/intel/pepc.git@release",
     "plotly>=5.18.0",
 ]
 


### PR DESCRIPTION
The pyproject currently declares `pepc` as a version-floor PyPI requirement (`pepc>=2.0.1`). Per the install guide at `docs/guide-install.md`, `pepc` is distributed via its GitHub repository (`intel/pepc`) and must be installed into the same venv before `stats-collect` for the dep to resolve cleanly. That ordering is easy to miss when somebody copy-pastes the standalone `pip3 install git+...stats-collect.git@release` example from the install guide into a fresh venv, or runs it from a script that didn't pre-install `pepc`.

Switching the dep to a PEP 440 direct URL reference (`pepc @ git+https://github.com/intel/pepc.git@release`) makes the install order-independent: `pip install git+...stats-collect.git@release` pulls `pepc` from the upstream repository regardless of whether it was pre-installed. The `@release` tag is the same one the install guide already uses, so the version pin behaviour is unchanged.

If `pepc` ever gets published to PyPI, this line can be flipped back to a regular version range without further effort.